### PR TITLE
Credential Profiles for AWSCLI calls.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
Adds entries to a project's generated config.env file to specify the credential profile used during AWS operations. These default to `default`, but can be changed by users that are strict about their privileges.

You can manage credentials by `aws --profile=any-profile-name config` and input credentials for different IAm users when prompted. You can use this to have one machine with AWSCLI installed that can access multiple AWS accounts. Helpful for service providers and enterprises with complex permissioning.
